### PR TITLE
The result of ts-jest config:migrate

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,22 +1,15 @@
 module.exports = {
-  "globals": {
-    "ts-jest": {
-      "skipBabel": true
-    }
-  },
-  "transform": {
-    "^.+\\.tsx?$": "ts-jest"
-  },
-  "testMatch": [
-    "**/?(*.)(spec).ts?(x)"
+  testMatch: [
+    '**/?(*.)(spec).ts?(x)',
   ],
   // Fixes/avoids https://github.com/facebook/jest/issues/6766
-  "testURL": "http://localhost",
-  "moduleFileExtensions": [
-    "ts",
-    "tsx",
-    "js",
-    "jsx",
-    "json"
-  ]
+  testURL: 'http://localhost',
+  moduleFileExtensions: [
+    'js',
+    'json',
+    'jsx',
+    'ts',
+    'tsx',
+  ],
+  preset: 'ts-jest',
 }


### PR DESCRIPTION
Now we no longer log:

```
[kafka-keyvalue-nodejs--sidecar-itest-56757ff6bc-qk44h itest] ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.skipBabel" is deprecated, use "[jest-config].globals.ts-jest.babelConfig" instead.
[kafka-keyvalue-nodejs--sidecar-itest-56757ff6bc-qk44h itest] ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
```

The reason I did this, and the reason there's no unit test for #2, and the reason for an upcoming PR that bumps nearly all dependencies, is that I had `./node_modules/.bin/jest` first taking like 30s to run then failing on an `expect` being reported as undefined. After messing back and forth I can no longer reproduce that error. Tests pass both with and without this change.