### PR TITLE
Add putOther to open up for generic kafka writes through pixy

### DIFF
--- a/src/KafkaKeyValue.spec.ts
+++ b/src/KafkaKeyValue.spec.ts
@@ -121,8 +121,7 @@ describe('KafkaKeyValue', function () {
       });
 
       // Promises needs to resolve before we get new value
-      await Promise.resolve();
-      await Promise.resolve();
+      await new Promise(resolve => setTimeout(resolve, 10));
 
       expect(onUpdateSpy).toHaveBeenCalledTimes(1);
       expect(onUpdateSpy).toHaveBeenCalledWith('bd3f6188-d865-443d-8646-03e8f1c643cb', { foo: 'bar' });

--- a/src/sidecar.itest.ts
+++ b/src/sidecar.itest.ts
@@ -20,6 +20,47 @@ describe('waiting for initial cache readiness', function () {
     server.close(done);
   });
 
+  beforeEach(() => {
+    promClient.register.clear();
+  });
+
+  it('is a lightweight way to let us write to any topic we can specify', async function () {
+
+    const metrics = KafkaKeyValue.createMetrics(promClient.Counter, promClient.Gauge, promClient.Histogram);
+    
+    const cache1 = new KafkaKeyValue({
+      cacheHost: 'http://localhost:8091',
+      metrics,
+      pixyHost: 'http://pixy',
+      topicName: 'sidecar-itest'
+    });
+
+    await cache1.onReady();
+
+    const cache2 = new KafkaKeyValue({
+      cacheHost: 'http://localhost:8092',
+      metrics,
+      pixyHost: 'http://pixy',
+      topicName: 'sidecar-itest-other'
+    });
+
+    await cache2.onReady();
+
+    const key = getUniqueKey('write_to_other');
+
+    const updateReceived = new Promise(resolve => cache2.onUpdate((updatedKey, value) => {
+      if (updatedKey === key) resolve();
+    }));
+
+    const updateWritten = cache1.putOther('sidecar-itest-other', key, { x: 'y' });
+
+    await updateWritten;
+    await updateReceived;
+
+    const value = await cache2.get(key);
+    expect(value).toEqual({ x: 'y' });
+  });
+
   it('lets us put and get values afterwards', async function () {
     const cache1 = new KafkaKeyValue({
       cacheHost: 'http://localhost:8091',

--- a/variant-dev/sidecar-itest.yaml
+++ b/variant-dev/sidecar-itest.yaml
@@ -43,6 +43,18 @@ spec:
             --partitions 50 \
             --replication-factor $REPLICATION_FACTOR \
             --config compression.type=uncompressed;
+          ./bin/kafka-topics.sh \
+            --zookeeper $ZOOKEEPER_CONNECT \
+            --topic sidecar-itest-other \
+            --delete \
+            --if-exists
+          ./bin/kafka-topics.sh \
+            --zookeeper $ZOOKEEPER_CONNECT \
+            --topic sidecar-itest-other \
+            --create \
+            --partitions 50 \
+            --replication-factor $REPLICATION_FACTOR \
+            --config compression.type=uncompressed;
       containers:
       - name: itest
         image: builds-registry.ystack.svc.cluster.local/yolean/kafka-keyvalue-nodejs-itest
@@ -69,6 +81,45 @@ spec:
               fieldPath: metadata.name
         - name: topic
           value: sidecar-itest
+        - name: kafka_max_poll_records
+          value: "1000"
+        - name: kafka_offset_reset
+          value: latest
+        - name: target
+          value: http://127.0.0.1/kafka-keyvalue/v1/updates
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: api
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: api
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        resources:
+          limits:
+            memory: 100Mi
+            cpu: 30m
+          requests:
+            memory: 100Mi
+            cpu: 30m
+      - name: kv-cache-other
+        image: solsson/kafka-keyvalue@sha256:a072f48f2ac9b30daeb2e78b7cada6091937b470504b31a1cc38d24e1b00d810
+        args:
+        - -Dquarkus.http.port=8092
+        ports:
+        - containerPort: 8092
+          name: api
+        env:
+        - name: kafka_bootstrap
+          value: bootstrap.kafka:9092
+        - name: kafka_group_id
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: topic
+          value: sidecar-itest-other
         - name: kafka_max_poll_records
           value: "1000"
         - name: kafka_offset_reset


### PR DESCRIPTION
…pic than the provided one

```
PASS src/sidecar.itest.ts (9.638s)
  waiting for initial cache readiness
    ✓ is a lightweight way to let us write to any topic we can specify (1725ms)
    ✓ lets us put and get values afterwards (781ms)
```