### PR TITLE
Handle terminating backends

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "./node_modules/.bin/jest",
+    "test": "KKV_FETCH_RETRY_INTERVAL_MS=1 ./node_modules/.bin/jest",
     "prepare": "rm -rf dist/ && tsc --skipLibCheck",
     "prepublishOnly": "npm test"
   },

--- a/src/KafkaKeyValue.spec.ts
+++ b/src/KafkaKeyValue.spec.ts
@@ -193,6 +193,7 @@ describe('KafkaKeyValue', function () {
 
       const streaming = kkv.streamValues(() => {});
       await Promise.resolve();
+      await Promise.resolve();
       response.body.emit('end');
 
       await streaming;

--- a/src/KafkaKeyValue.ts
+++ b/src/KafkaKeyValue.ts
@@ -9,12 +9,12 @@ const pGunzip = promisify<InputType, Buffer>(gunzip);
 const pGzip = promisify<InputType, Buffer>(gzip);
 
 const KKV_CACHE_HOST_READINESS_ENDPOINT = process.env.KKV_CACHE_HOST_READINESS_ENDPOINT || '/q/health/ready';
-const LAST_SEEN_OFFSETS_HEADER_NAME = 'x-kkv-last-seen-offsets';
+export const LAST_SEEN_OFFSETS_HEADER_NAME = 'x-kkv-last-seen-offsets';
 
-const KKV_FETCH_RETRY_OPTIONS = {
+export const KKV_FETCH_RETRY_OPTIONS = Object.freeze({
   intervalMs: Number.parseInt(process.env.KKV_FETCH_RETRY_INTERVAL_MS || '') || 1000,
   nRetries: Number.parseInt(process.env.KKV_FETCH_NUMBER_RETRIES || '') || 5
-};
+});
 
 export interface IKafkaKeyValueImpl { new (options: IKafkaKeyValue): KafkaKeyValue }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ export const ON_UPDATE_DEFAULT_PATH = '/kafka-keyvalue/v1/updates';
 export function getOnUpdateRoute(): any {
   return [bodyParser.json({}), (req: Request, res: Response) => {
     const body = req.body;
-    logger.debug({ body, req }, 'Incoming onupdate webhook');
+    logger.debug({
+      remoteAddress: req.connection && req.connection.remoteAddress,
+      topic: req.get('x-kkv-topic'),
+      offsets: req.get('x-kkv-offsets'),
+    }, 'Incoming onupdate webhook');
     updateEvents.emit('update', body);
     res.sendStatus(204);
   }];


### PR DESCRIPTION
Our setup with kkv should only _require_ us to handle pod terminations causing request _errors_. With that in mind, I have scoped out retrying on non-OK status codes.

kkv-clients now log these kind of messages when a request to a terminating kkv-pod results in an error. `retriesLeft` implies how many attempts failed for the same request from the application.
```
[2023-08-17T15:21:25.384+02:00]  WARN: kkv:kkv-userstate:8080/1 on live-v3-5f56d56b79-frqmj: Get request failed, retrying (retriesLeft=4, key=a27038f2-c9b1-424a-baac-728ecc5294b9)
    error: {
      "message": "request to http://kkv-userstate:8080/cache/v1/raw/a27038f2-c9b1-424a-baac-728ecc5294b9 failed, reason: connect ETIMEDOUT 10.4.34.217:8080",
      "type": "system",
      "errno": "ETIMEDOUT",
      "code": "ETIMEDOUT"
    }
```