### PR TITLE
Abort slow get requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yolean/kafka-keyvalue",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "keywords": [],
   "author": "Yolean AB",
   "license": "Apache-2.0",

--- a/src/KafkaKeyValue.spec.ts
+++ b/src/KafkaKeyValue.spec.ts
@@ -3,7 +3,7 @@ import updateEvents from './update-events';
 import { EventEmitter } from 'events';
 import { fail } from 'assert';
 import { LabelValues } from 'prom-client';
-import { BodyInit, RequestInit } from 'node-fetch';
+import { RequestInit } from 'node-fetch';
 
 const promClientMock = {
   Counter: class Counter {

--- a/src/KafkaKeyValue.spec.ts
+++ b/src/KafkaKeyValue.spec.ts
@@ -3,6 +3,7 @@ import updateEvents from './update-events';
 import { EventEmitter } from 'events';
 import { fail } from 'assert';
 import { LabelValues } from 'prom-client';
+import { BodyInit, RequestInit } from 'node-fetch';
 
 const promClientMock = {
   Counter: class Counter {
@@ -67,6 +68,61 @@ const promClientMock = {
 };
 
 describe('KafkaKeyValue', function () {
+
+  it('can be told to abort slow get requests', async function () {
+    const fetchMock = jest.fn();
+
+    const metrics = KafkaKeyValue.createMetrics(promClientMock.Counter, promClientMock.Gauge, promClientMock.Histogram);
+    const kkv = new KafkaKeyValue({
+      cacheHost: 'http://cache-kkv',
+      metrics,
+      pixyHost: 'http://pixy',
+      topicName: 'testtopic01',
+      fetchImpl: fetchMock,
+    });
+
+    const successGetResponse = {
+      status: 200,
+      ok: true,
+      json: async () => ({ myvalue: true }),
+      headers: new Map([
+        [LAST_SEEN_OFFSETS_HEADER_NAME, JSON.stringify([])]
+      ])
+    };
+
+    const respondSlowlyButSuccessfullyIfAllowed = (url: string, options: RequestInit) => {
+      return new Promise((resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          reject(new Error('MOCK_ABORTED_REQUEST'));
+          clearTimeout(timer);
+        });
+        const timer = setTimeout(() => {
+          resolve(successGetResponse);
+        }, timeoutMs * 2);
+      })
+    };
+
+    const timeoutMs = 100;
+
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+
+    await expect(kkv.get('k1', { abortRequestsAfterMs: timeoutMs })).rejects.toEqual(new Error('MOCK_ABORTED_REQUEST'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockImplementationOnce(respondSlowlyButSuccessfullyIfAllowed);
+    fetchMock.mockResolvedValueOnce(successGetResponse);
+
+    await expect(kkv.get('k1', { abortRequestsAfterMs: timeoutMs })).resolves.toEqual({ myvalue: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(6 + 3);
+  });
 
   it('get does not retry on 404s by default', async function () {
     const fetchMock = jest.fn();

--- a/src/KafkaKeyValue.spec.ts
+++ b/src/KafkaKeyValue.spec.ts
@@ -202,7 +202,7 @@ describe('KafkaKeyValue', function () {
 
       await expect(kkv.updateListener(update)).rejects.toEqual(new Error('Cache does not contain key: key1'));
 
-      expect(fetchMock.mock.calls).toEqual([
+      expect(fetchMock.mock.calls.map(args => [args[0]])).toEqual([
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],
@@ -268,7 +268,7 @@ describe('KafkaKeyValue', function () {
       updateEvents.emit('update', update);
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      expect(fetchMock.mock.calls).toEqual([
+      expect(fetchMock.mock.calls.map(args => [args[0]])).toEqual([
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],
@@ -349,7 +349,7 @@ describe('KafkaKeyValue', function () {
       updateEvents.emit('update', update);
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      expect(fetchMock.mock.calls).toEqual([
+      expect(fetchMock.mock.calls.map(args => [args[0]])).toEqual([
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],
         ['http://cache-kkv/cache/v1/raw/key1'],


### PR DESCRIPTION
```
[2023-09-21T14:36:03.404+02:00]  WARN: kkv:kkv-userstate:8080/1 on boards-6bf4d7f65b-sm7nm: Get request failed, retrying (retriesLeft=4, key=afbde9aa-7520-4289-8975-70f414bc012e)
    error: {
      "type": "aborted",
      "message": "The user aborted a request."
    }
```
The idea is that we get these kind of messages which tell us when we avoided hanging the user's request in cases where a backend pod is not answering quickly, during termination for example.